### PR TITLE
fix(migrate): handle legacy kig-pins.json raw-list shape

### DIFF
--- a/src/kig_migrate.py
+++ b/src/kig_migrate.py
@@ -36,8 +36,17 @@ def migrate_legacy(*, claude_home: Path, kig_home: Path) -> None:
     if pins_src.exists():
         try:
             data = json.loads(pins_src.read_text())
-            for text in data.get("pins", []):
-                if text:
+            # Two legacy shapes exist in the wild:
+            #   dict: {"pins": ["a", "b"]}
+            #   list: ["a", "b"]                 ← earlier rough cut
+            if isinstance(data, dict):
+                pins = data.get("pins", [])
+            elif isinstance(data, list):
+                pins = data
+            else:
+                pins = []
+            for text in pins:
+                if isinstance(text, str) and text:
                     add_entry(inject_path, text=text, for_modes=["all"])
         except json.JSONDecodeError:
             pass

--- a/tests/test_kig_migrate.py
+++ b/tests/test_kig_migrate.py
@@ -80,6 +80,23 @@ def test_archive_preserves_prior_when_destination_exists(tmp_path):
     assert timestamped[0].name.startswith("kig-pins.json.")
 
 
+def test_migrates_pins_file_list_shape(tmp_path):
+    """Legacy raw-list shape (from earlier rough-cut): [\"a\", \"b\"]."""
+    claude_home = tmp_path / ".claude"
+    kig_home = claude_home / "kig"
+    claude_home.mkdir()
+    (claude_home / "kig-pins.json").write_text(
+        json.dumps(["bare list entry 1", "bare list entry 2"])
+    )
+    migrate_legacy(claude_home=claude_home, kig_home=kig_home)
+    store = load_store(kig_home / "inject.json")
+    assert [e.text for e in store.entries] == [
+        "bare list entry 1",
+        "bare list entry 2",
+    ]
+    assert (kig_home / "legacy" / "kig-pins.json").exists()
+
+
 def test_handles_corrupt_pins_json(tmp_path):
     """Bad JSON in pins file is swallowed; file is still archived; no crash."""
     claude_home = tmp_path / ".claude"


### PR DESCRIPTION
## Summary

Real-world install on Matt's machine crashed:
\`\`\`
AttributeError: 'list' object has no attribute 'get'
\`\`\`

The legacy \`~/.claude/kig-pins.json\` stored pins as a bare list \`["a", "b"]\` rather than the assumed \`{"pins": [...]}\` dict. Migration now handles both shapes.

## Test plan
- [x] New test \`test_migrates_pins_file_list_shape\` covers the raw-list path; 7/7 pass in \`test_kig_migrate.py\`